### PR TITLE
Add automatic provider prepare

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,25 @@ jobs:
           actions-runner-ephemeral-autoscaler-lxd -org ${{ vars.TEST_ORG }} -repo ${{ vars.TEST_REPO }} -labels ${{ env.RUNNER_LABEL }} &
           sleep 1
 
-      - name: wait for autoscaler to be ready
+      - name: wait for autoscaler start preparing
+        timeout-minutes: 1
         shell: bash {0}
-        run: |
-          while ! curl -s localhost:9090/metrics | grep -q 'actions_runner_autoscaler_idle.*[1-9]'; do
-            echo "Waiting for autoscaler to be ready..."
-            curl -s localhost:9090/metrics | grep actions_runner_autoscaler
-            sleep 5
-          done
+        run: ./scripts/wait-metric-expr.sh preparing 1
+
+      - name: wait for autoscaler finish preparing
+        timeout-minutes: 15
+        shell: bash {0}
+        run: ./scripts/wait-metric-expr.sh preparing 0
+
+      - name: wait for autoscaler starting state
+        timeout-minutes: 5
+        shell: bash {0}
+        run: ./scripts/wait-metric-expr.sh starting 1
+      
+      - name: wait for autoscaler idle state
+        timeout-minutes: 5
+        shell: bash {0}
+        run: ./scripts/wait-metric-expr.sh idle 1
 
       - name: run test workflow
         env:

--- a/providers/interfaces/provider.go
+++ b/providers/interfaces/provider.go
@@ -1,6 +1,9 @@
 package interfaces
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // RunnerDispositionMetrics represents the metrics of runner instances in different states
 type RunnerDispositionMetrics interface {
@@ -19,6 +22,7 @@ type RunnerDispositionMetrics interface {
 
 // Provider represents a compute provider interface
 type Provider interface {
+	ImageCreatedAt(ctx context.Context) (time.Time, error)
 	// PrepareImage preheats an image with required packages
 	PrepareImage(ctx context.Context) error
 

--- a/scripts/wait-metric-expr.sh
+++ b/scripts/wait-metric-expr.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Usage:   wait-metric-expr.sh <metric suffix> <value or regex>
+# Example: wait-metric-expr.sh idle 1
+
+name=$1
+expr=$2
+
+while ! curl -s localhost:9090/metrics | grep -E "^actions_runner_autoscaler_${name}.*${expr}"; do
+  echo "Waiting for autoscaler instances to be ready..."
+  curl -s localhost:9090/metrics | grep -E '^actions_runner_autoscaler'
+  echo ""
+  sleep 5
+done


### PR DESCRIPTION
Automatically call prepare if image is more than a week old. Check every 500 autoscale loops.

Add metrics and make CI results a bit more clear by waiting for each stage individually.

Closes https://github.com/gartnera/actions-runner-ephemeral-autoscaler/issues/1 and https://github.com/gartnera/actions-runner-ephemeral-autoscaler/issues/6